### PR TITLE
Mavenbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ The following is the list of changes, which the commit history should easily ref
 We are working on the [TouchCORE](http://touchcore.cs.mcgill.ca) (formerly TouchRAM) project in the [Software Engineering Laboratory](http://www.cs.mcgill.ca/~joerg/SEL/SEL_Home.html) at [McGill University](http://www.mcgill.ca). When we started developing our application, MT4j v0.98 was freshly released. Unfortunately, it was never updated since, which lead us to making some adjustments our own (besides extending some of MT4j's components in our project). We always had the problem of running it with Java 7 and higher on OSX, because of JOGL 1.x only working with the JRE provided by Apple. We worked with this constraint for a long time, but finally made the switch due to other constraints, thanks to some helpful pointers we found in the [UltraCom project](https://github.com/lodsb/UltraCom/tree/proc2) (which unfortunately has many more modifications to MT4j).
 
 Because there are probably more people out there facing the same problem, we are sharing this updated version. Hope it helps! :)
+
+## How!
+
+This sections explains how to configure eclipse to actually build this library for further reuse:
+
+ * Clone this repo
+ * Make sure eclipse uses JDK 1.8 as runtime and compiler compliance:
+   * Right-click on project -> properties -> Java Build Path -> Libraries -> Remove JDK13, add JDK 1.8 (```brew cask install adoptopenjdk8```)
+   * Right-click on project -> properties -> Java Compiler -> Enable project specific settings, compiler compliance level = 1.8
+ * Clean and build: Project -> Clean...
+ * Make sure the tests pass:
+   * mt4j-core -> examples -> basic.helloworld -> Right-click: StartHelloWorld -> Run as... -> Java application
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Because there are probably more people out there facing the same problem, we are
 
 This sections explains how to configure eclipse to actually build this library for further reuse:
 
+
+### Project configurations
+
  * Clone this repo
  * Make sure eclipse uses JDK 1.8 as runtime and compiler compliance:
    * Right-click on project -> properties -> Java Build Path -> Libraries -> Remove JDK13, add JDK 1.8 (```brew cask install adoptopenjdk8```)
@@ -42,4 +45,25 @@ This sections explains how to configure eclipse to actually build this library f
  * Clean and build: Project -> Clean...
  * Make sure the tests pass:
    * mt4j-core -> examples -> basic.helloworld -> Right-click: StartHelloWorld -> Run as... -> Java application
+
+### Build a JAR
+
+ * Right click on ```build.xml``` -> Run As... -> Ant Build  
+Alternatively: ```cd mt4j-core; ant create_run_jar```
+ * This generates a new file, for further use as MT4J-library: **mt4j-core/mt4j.jar**
+
+ > *Note:* Unfortunately the ant build requires the compiled classes in a ```bin```subfolder (Created by eclipse: ```clean & build```). So you can not avoid eclipse.
+
+### Mavenize it
+
+ * To build a local maven artifact, based on this jar:  
+```mvn install:install-file -Dfile=mt4j.jar -DgroupId=friend.of.mcgillsel -DartifactId=mt4j -Dversion=mspatch-1.0 -Dpackaging=jar -DcreateChecksum=true```
+ * From here on you can simply refer to mt4j in your maven projects, using the following snippet:  
+```xml
+<dependency>
+	<groupId>friend.of.mcgillsel</groupId>
+	<artifactId>mt4j</artifactId>
+	<version>mspatch-1.0</version>
+</dependency>
+```
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,12 @@ Because there are probably more people out there facing the same problem, we are
 
 ## How!
 
-This sections explains how to configure eclipse to actually build this library for further reuse:
-
+This sections explains how to configure Eclipse to actually build this library for further reuse:
 
 ### Project configurations
 
  * Clone this repo
- * Make sure eclipse uses JDK 1.8 as runtime and compiler compliance:
+ * Make sure Eclipse uses JDK 1.8 as runtime and compiler compliance:
    * Right-click on project -> properties -> Java Build Path -> Libraries -> Remove JDK13, add JDK 1.8 (```brew cask install adoptopenjdk8```)
    * Right-click on project -> properties -> Java Compiler -> Enable project specific settings, compiler compliance level = 1.8
  * Clean and build: Project -> Clean...
@@ -52,13 +51,13 @@ This sections explains how to configure eclipse to actually build this library f
 Alternatively: ```cd mt4j-core; ant create_run_jar```
  * This generates a new file, for further use as MT4J-library: **mt4j-core/mt4j.jar**
 
- > *Note:* Unfortunately the ant build requires the compiled classes in a ```bin```subfolder (Created by eclipse: ```clean & build```). So you can not avoid eclipse.
+ > *Note:* Unfortunately the Ant build requires the compiled classes in a ```bin```subfolder (Created by Eclipse: ```clean & build```). So you can not avoid Eclipse.
 
 ### Mavenize it
 
- * To build a local maven artifact, based on this jar:  
+ * To build a local Maven artifact, based on this jar:  
 ```mvn install:install-file -Dfile=mt4j.jar -DgroupId=friend.of.mcgillsel -DartifactId=mt4j -Dversion=mspatch-1.0 -Dpackaging=jar -DcreateChecksum=true```
- * From here on you can simply refer to mt4j in your maven projects, using the following snippet:  
+ * From here on you can simply refer to mt4j in your Maven projects, using the following snippet:  
 ```xml
 <dependency>
 	<groupId>friend.of.mcgillsel</groupId>


### PR DESCRIPTION
Added detailed project setup instructions to README, including an additional wrap-up of the generated MT4J jar as a local maven artifact, for easy integration in external maven projects.